### PR TITLE
Feature: Access permissions to k8s Services

### DIFF
--- a/eks/iam-role/clusterrole.yaml
+++ b/eks/iam-role/clusterrole.yaml
@@ -29,6 +29,8 @@ rules:
   - services
   - namespaces
   - replicationcontrollers
+  - services/proxy
+  - pods/portforward
   verbs:
   - get
   - list

--- a/eks/service-account-token/rbac.yaml
+++ b/eks/service-account-token/rbac.yaml
@@ -33,6 +33,8 @@ rules:
       - services
       - namespaces
       - replicationcontrollers
+      - services/proxy
+      - pods/portforward
     verbs:
       - get
       - list


### PR DESCRIPTION
This branch adds proxy and port-forward permissions to the ClusterRoles created by the customers when creating an EKS data source - to allow communicating with customers' services that are not exposed outside of the cluster (e.g. inner prometheus, jaeger, etc.).