### PR TITLE
Add agentless EKS enrollment support to aws-generic templates

### DIFF
--- a/aws-generic/cloud-formation/management-account.yaml
+++ b/aws-generic/cloud-formation/management-account.yaml
@@ -84,6 +84,11 @@ Parameters:
     Type: String
     Default: 'false'
     AllowedValues: ['true', 'false']
+  EnableAgentlessEKS:
+    Type: String
+    Default: 'false'
+    AllowedValues: ['true', 'false']
+    Description: Enable opt-in agentless EKS monitoring across the organization (creates a dedicated Dalton-EKS-Agentless role and grants each viewer role permission to auto-enroll EKS access entries)
 
   # StackSet regions
   TargetRegions:
@@ -95,6 +100,12 @@ Conditions:
   DeployToOrganization: !Equals [!Ref DeploymentTarget, 'organization']
   CreateManagementAccountRole: !Equals [!Ref IncludeManagementAccount, 'true']
   FullAccessEnabled: !Equals [!Ref EnableFullAccess, 'true']
+  AgentlessEKSEnabled: !Equals [!Ref EnableAgentlessEKS, 'true']
+  # Agentless EKS resources for the management account only apply when the management
+  # account viewer role is also being created.
+  CreateMgmtAgentlessEKS: !And
+    - !Condition CreateManagementAccountRole
+    - !Condition AgentlessEKSEnabled
   # Individual service conditions - only create when Full Access is NOT enabled
   # This avoids creating redundant policies when Full Access already covers everything
   S3Enabled: !And
@@ -270,6 +281,8 @@ Resources:
           ParameterValue: !Ref EnableSecretsManager
         - ParameterKey: EnableRoute53
           ParameterValue: !Ref EnableRoute53
+        - ParameterKey: EnableAgentlessEKS
+          ParameterValue: !Ref EnableAgentlessEKS
       StackInstancesGroup:
         - DeploymentTargets:
             OrganizationalUnitIds: !If
@@ -575,6 +588,72 @@ Resources:
               - 'ssm:GetParametersByPath'
             Resource: '*'
 
+  #############################################
+  # Agentless EKS resources (Management Account, opt-in)
+  # Only created when IncludeManagementAccount AND EnableAgentlessEKS are both 'true'.
+  # Member accounts receive the equivalent resources via the StackSet (stackset.yaml).
+  #############################################
+  MgmtDaltonEKSAgentlessRole:
+    Type: AWS::IAM::Role
+    Condition: CreateMgmtAgentlessEKS
+    DependsOn: DaltonViewerRole
+    Properties:
+      RoleName: !Sub 'Dalton-EKS-Agentless-${AWS::AccountId}'
+      Description: 'Role assumed by the Dalton collector for agentless EKS monitoring (management account)'
+      MaxSessionDuration: 3600
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: 'arn:aws:iam::767398131998:user/vaticy-cluster-watcher'
+            Action: 'sts:AssumeRole'
+            Condition:
+              StringEquals:
+                'sts:ExternalId': !Ref ExternalId
+      Policies:
+        - PolicyName: !Sub 'Dalton-EKS-Agentless-Describe-${AWS::AccountId}'
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: EKSDescribeCluster
+                Effect: Allow
+                Action:
+                  - 'eks:DescribeCluster'
+                Resource: !Sub 'arn:aws:eks:*:${AWS::AccountId}:cluster/*'
+
+  MgmtDaltonAWSRoleAgentlessEKSPolicy:
+    Type: AWS::IAM::RolePolicy
+    Condition: CreateMgmtAgentlessEKS
+    Properties:
+      RoleName: !Ref DaltonViewerRole
+      PolicyName: !Sub 'Dalton-EKS-Agentless-Enroll-${AWS::AccountId}'
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: EKSManageAgentlessAccessEntry
+            Effect: Allow
+            Action:
+              - 'eks:CreateAccessEntry'
+              - 'eks:DeleteAccessEntry'
+              - 'eks:DescribeAccessEntry'
+            Resource: '*'
+            Condition:
+              StringEquals:
+                'eks:principalArn': !Sub 'arn:aws:iam::${AWS::AccountId}:role/Dalton-EKS-Agentless-${AWS::AccountId}'
+          - Sid: EKSManageAgentlessAccessPolicy
+            Effect: Allow
+            Action:
+              - 'eks:AssociateAccessPolicy'
+              - 'eks:DisassociateAccessPolicy'
+            # AssociateAccessPolicy/DisassociateAccessPolicy do not support the
+            # eks:principalArn condition key, so scope the resource to the agentless
+            # role's access-entry ARN to prevent attaching AdminView to arbitrary principals.
+            Resource: !Sub 'arn:aws:eks:*:${AWS::AccountId}:access-entry/*/role/${AWS::AccountId}/Dalton-EKS-Agentless-${AWS::AccountId}/*'
+            Condition:
+              StringEquals:
+                'eks:policyArn': 'arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminViewPolicy'
+
 Outputs:
   OrganizationsRoleArn:
     Description: ARN of the IAM role for listing organization accounts (use this for Dalton configuration)
@@ -588,6 +667,11 @@ Outputs:
   ViewerRoleName:
     Description: Name of the viewer role deployed to member accounts
     Value: Dalton-AWS-Viewer
+
+  AgentlessEKSRoleArn:
+    Condition: CreateMgmtAgentlessEKS
+    Description: The ARN of the agentless EKS role Dalton assumes to monitor EKS clusters in this management account
+    Value: !GetAtt MgmtDaltonEKSAgentlessRole.Arn
 
   ExternalId:
     Description: External ID used for secure cross-account access

--- a/aws-generic/cloud-formation/management-account.yaml
+++ b/aws-generic/cloud-formation/management-account.yaml
@@ -606,7 +606,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: 'arn:aws:iam::767398131998:user/vaticy-cluster-watcher'
+              AWS: 'arn:aws:iam::767398131998:role/DaltonCollectorRole'
             Action: 'sts:AssumeRole'
             Condition:
               StringEquals:

--- a/aws-generic/cloud-formation/single-account.yaml
+++ b/aws-generic/cloud-formation/single-account.yaml
@@ -525,7 +525,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: 'arn:aws:iam::767398131998:user/vaticy-cluster-watcher'
+              AWS: 'arn:aws:iam::767398131998:role/DaltonCollectorRole'
             Action: 'sts:AssumeRole'
             Condition:
               StringEquals:

--- a/aws-generic/cloud-formation/single-account.yaml
+++ b/aws-generic/cloud-formation/single-account.yaml
@@ -38,6 +38,10 @@ Metadata:
           default: Security Services
         Parameters:
           - EnableSecretsManager
+      - Label:
+          default: Kubernetes Services
+        Parameters:
+          - EnableAgentlessEKS
 
 Parameters:
   ExternalId:
@@ -143,6 +147,14 @@ Parameters:
       - 'false'
     Description: Enable read-only access to Amazon Route 53
 
+  EnableAgentlessEKS:
+    Type: String
+    Default: 'false'
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Description: Enable opt-in agentless EKS monitoring (creates a dedicated Dalton-EKS-Agentless role and grants the viewer role permission to auto-enroll EKS access entries)
+
 Conditions:
   FullAccessEnabled: !Equals [!Ref EnableFullAccess, 'true']
   NotFullAccess: !Not [!Equals [!Ref EnableFullAccess, 'true']]
@@ -158,6 +170,7 @@ Conditions:
   SQSEnabled: !And [!Equals [!Ref EnableSQS, 'true'], !Condition NotFullAccess]
   SecretsManagerEnabled: !And [!Equals [!Ref EnableSecretsManager, 'true'], !Condition NotFullAccess]
   Route53Enabled: !And [!Equals [!Ref EnableRoute53, 'true'], !Condition NotFullAccess]
+  AgentlessEKSEnabled: !Equals [!Ref EnableAgentlessEKS, 'true']
 
 Resources:
   DaltonAWSRole:
@@ -497,6 +510,78 @@ Resources:
               - 'route53:ListQueryLoggingConfigs'
             Resource: '*'
 
+  # Agentless EKS role (opt-in)
+  # Dedicated role assumed by the Dalton collector to read EKS clusters directly,
+  # without deploying a per-cluster agent. Only created when EnableAgentlessEKS is 'true'.
+  DaltonEKSAgentlessRole:
+    Type: AWS::IAM::Role
+    Condition: AgentlessEKSEnabled
+    Properties:
+      RoleName: !Sub 'Dalton-EKS-Agentless-${AWS::AccountId}'
+      Description: 'Role assumed by the Dalton collector for agentless EKS monitoring'
+      MaxSessionDuration: 3600
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: 'arn:aws:iam::767398131998:user/vaticy-cluster-watcher'
+            Action: 'sts:AssumeRole'
+            Condition:
+              StringEquals:
+                'sts:ExternalId': !Ref ExternalId
+      Policies:
+        - PolicyName: !Sub 'Dalton-EKS-Agentless-Describe-${AWS::AccountId}'
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: EKSDescribeCluster
+                Effect: Allow
+                Action:
+                  - 'eks:DescribeCluster'
+                Resource: !Sub 'arn:aws:eks:*:${AWS::AccountId}:cluster/*'
+      Tags:
+        - Key: ManagedBy
+          Value: Dalton
+        - Key: Purpose
+          Value: EKS-Agentless
+
+  # Agentless EKS auto-enrollment permissions (opt-in)
+  # Attached to the existing viewer role as a separate RolePolicy so the flag-off
+  # template is byte-for-byte unchanged in effect. Grants the viewer role the ability
+  # to enroll the agentless role above into cluster access entries.
+  DaltonAWSRoleAgentlessEKSPolicy:
+    Type: AWS::IAM::RolePolicy
+    Condition: AgentlessEKSEnabled
+    Properties:
+      RoleName: !Ref DaltonAWSRole
+      PolicyName: !Sub 'Dalton-EKS-Agentless-Enroll-${AWS::AccountId}'
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: EKSManageAgentlessAccessEntry
+            Effect: Allow
+            Action:
+              - 'eks:CreateAccessEntry'
+              - 'eks:DeleteAccessEntry'
+              - 'eks:DescribeAccessEntry'
+            Resource: '*'
+            Condition:
+              StringEquals:
+                'eks:principalArn': !Sub 'arn:aws:iam::${AWS::AccountId}:role/Dalton-EKS-Agentless-${AWS::AccountId}'
+          - Sid: EKSManageAgentlessAccessPolicy
+            Effect: Allow
+            Action:
+              - 'eks:AssociateAccessPolicy'
+              - 'eks:DisassociateAccessPolicy'
+            # AssociateAccessPolicy/DisassociateAccessPolicy do not support the
+            # eks:principalArn condition key, so scope the resource to the agentless
+            # role's access-entry ARN to prevent attaching AdminView to arbitrary principals.
+            Resource: !Sub 'arn:aws:eks:*:${AWS::AccountId}:access-entry/*/role/${AWS::AccountId}/Dalton-EKS-Agentless-${AWS::AccountId}/*'
+            Condition:
+              StringEquals:
+                'eks:policyArn': 'arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminViewPolicy'
+
 Outputs:
   RoleArn:
     Description: The ARN of the created IAM Role for Dalton
@@ -515,3 +600,8 @@ Outputs:
   ExternalId:
     Description: The External ID used for this integration
     Value: !Ref ExternalId
+
+  AgentlessEKSRoleArn:
+    Condition: AgentlessEKSEnabled
+    Description: The ARN of the agentless EKS role Dalton assumes to monitor EKS clusters
+    Value: !GetAtt DaltonEKSAgentlessRole.Arn

--- a/aws-generic/cloud-formation/stackset.yaml
+++ b/aws-generic/cloud-formation/stackset.yaml
@@ -528,7 +528,7 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: 'arn:aws:iam::767398131998:user/vaticy-cluster-watcher'
+              AWS: 'arn:aws:iam::767398131998:role/DaltonCollectorRole'
             Action: 'sts:AssumeRole'
             Condition:
               StringEquals:

--- a/aws-generic/cloud-formation/stackset.yaml
+++ b/aws-generic/cloud-formation/stackset.yaml
@@ -38,6 +38,10 @@ Metadata:
           default: Security Services
         Parameters:
           - EnableSecretsManager
+      - Label:
+          default: Kubernetes Services
+        Parameters:
+          - EnableAgentlessEKS
 
 Parameters:
   ExternalId:
@@ -143,6 +147,14 @@ Parameters:
       - 'false'
     Description: Enable read-only access to Amazon Route 53
 
+  EnableAgentlessEKS:
+    Type: String
+    Default: 'false'
+    AllowedValues:
+      - 'true'
+      - 'false'
+    Description: Enable opt-in agentless EKS monitoring (creates a dedicated Dalton-EKS-Agentless role and grants the viewer role permission to auto-enroll EKS access entries)
+
 Conditions:
   FullAccessEnabled: !Equals [!Ref EnableFullAccess, 'true']
   NotFullAccess: !Not [!Equals [!Ref EnableFullAccess, 'true']]
@@ -158,6 +170,7 @@ Conditions:
   SQSEnabled: !And [!Equals [!Ref EnableSQS, 'true'], !Condition NotFullAccess]
   SecretsManagerEnabled: !And [!Equals [!Ref EnableSecretsManager, 'true'], !Condition NotFullAccess]
   Route53Enabled: !And [!Equals [!Ref EnableRoute53, 'true'], !Condition NotFullAccess]
+  AgentlessEKSEnabled: !Equals [!Ref EnableAgentlessEKS, 'true']
 
 Resources:
   # IAM Role with fixed name for consistency across all accounts in the organization
@@ -500,6 +513,80 @@ Resources:
               - 'route53:ListQueryLoggingConfigs'
             Resource: '*'
 
+  # Agentless EKS role (opt-in)
+  # Dedicated role assumed by the Dalton collector to read EKS clusters directly,
+  # without deploying a per-cluster agent. Only created when EnableAgentlessEKS is 'true'.
+  DaltonEKSAgentlessRole:
+    Type: AWS::IAM::Role
+    Condition: AgentlessEKSEnabled
+    Properties:
+      RoleName: !Sub 'Dalton-EKS-Agentless-${AWS::AccountId}'
+      Description: 'Role assumed by the Dalton collector for agentless EKS monitoring (deployed via StackSet)'
+      MaxSessionDuration: 3600
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: 'arn:aws:iam::767398131998:user/vaticy-cluster-watcher'
+            Action: 'sts:AssumeRole'
+            Condition:
+              StringEquals:
+                'sts:ExternalId': !Ref ExternalId
+      Policies:
+        - PolicyName: !Sub 'Dalton-EKS-Agentless-Describe-${AWS::AccountId}'
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Sid: EKSDescribeCluster
+                Effect: Allow
+                Action:
+                  - 'eks:DescribeCluster'
+                Resource: !Sub 'arn:aws:eks:*:${AWS::AccountId}:cluster/*'
+      Tags:
+        - Key: ManagedBy
+          Value: Dalton
+        - Key: Purpose
+          Value: EKS-Agentless
+        - Key: DeploymentMethod
+          Value: StackSet
+
+  # Agentless EKS auto-enrollment permissions (opt-in)
+  # Attached to the existing viewer role as a separate RolePolicy so the flag-off
+  # template is byte-for-byte unchanged in effect. Grants the viewer role the ability
+  # to enroll the agentless role above into cluster access entries.
+  DaltonAWSRoleAgentlessEKSPolicy:
+    Type: AWS::IAM::RolePolicy
+    Condition: AgentlessEKSEnabled
+    Properties:
+      RoleName: !Ref DaltonAWSRole
+      PolicyName: !Sub 'Dalton-EKS-Agentless-Enroll-${AWS::AccountId}'
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Sid: EKSManageAgentlessAccessEntry
+            Effect: Allow
+            Action:
+              - 'eks:CreateAccessEntry'
+              - 'eks:DeleteAccessEntry'
+              - 'eks:DescribeAccessEntry'
+            Resource: '*'
+            Condition:
+              StringEquals:
+                'eks:principalArn': !Sub 'arn:aws:iam::${AWS::AccountId}:role/Dalton-EKS-Agentless-${AWS::AccountId}'
+          - Sid: EKSManageAgentlessAccessPolicy
+            Effect: Allow
+            Action:
+              - 'eks:AssociateAccessPolicy'
+              - 'eks:DisassociateAccessPolicy'
+            # AssociateAccessPolicy/DisassociateAccessPolicy do not support the
+            # eks:principalArn condition key, so scope the resource to the agentless
+            # role's access-entry ARN to prevent attaching AdminView to arbitrary principals.
+            Resource: !Sub 'arn:aws:eks:*:${AWS::AccountId}:access-entry/*/role/${AWS::AccountId}/Dalton-EKS-Agentless-${AWS::AccountId}/*'
+            Condition:
+              StringEquals:
+                'eks:policyArn': 'arn:aws:eks::aws:cluster-access-policy/AmazonEKSAdminViewPolicy'
+
 Outputs:
   RoleArn:
     Description: The ARN of the created IAM Role for Dalton
@@ -516,3 +603,8 @@ Outputs:
   ExternalId:
     Description: The External ID used for this integration
     Value: !Ref ExternalId
+
+  AgentlessEKSRoleArn:
+    Condition: AgentlessEKSEnabled
+    Description: The ARN of the agentless EKS role Dalton assumes to monitor EKS clusters
+    Value: !GetAtt DaltonEKSAgentlessRole.Arn


### PR DESCRIPTION
## Summary
- New `EnableAgentlessEKS` parameter (default `false`) on `single-account.yaml`, `stackset.yaml`, and `management-account.yaml` — default-off is a functional no-op
- When enabled, each target account gets a `Dalton-EKS-Agentless-{AccountId}` role (trusted by the collector principal with the stack's External ID, `eks:DescribeCluster` only)
- The existing `Dalton-AWS-Viewer` role gains a conditional enrollment policy: `eks:CreateAccessEntry`/`DeleteAccessEntry`/`DescribeAccessEntry` condition-keyed to the agentless role's principal ARN, and `eks:AssociateAccessPolicy`/`DisassociateAccessPolicy` resource-scoped to the agentless role's access-entry ARN and pinned to `AmazonEKSAdminViewPolicy`
- `management-account.yaml` passes the parameter through the member-account StackSet and covers the `IncludeManagementAccount` viewer-role path
- Conditional `AgentlessEKSRoleArn` output on all three templates

## Linear
- [ENG-4257](https://linear.app/dalton-ai/issue/ENG-4257)

## Deploy prerequisites
- `arn:aws:iam::767398131998:role/DaltonCollectorRole` must exist in Dalton's account **before** any customer deploys with `EnableAgentlessEKS=true` — IAM resolves the trust-policy principal at stack-create time and fails on a nonexistent ARN. (Role-based trust replaces the legacy `vaticy-cluster-watcher` IAM user; collector-side change tracked separately.)

## Test plan
- [ ] Deploy `single-account.yaml` with the parameter unset — stack must synthesize identically to today (no new resources)
- [ ] Deploy with `EnableAgentlessEKS=true` — agentless role + enrollment policy created; `AgentlessEKSRoleArn` output present
- [ ] Verify the viewer role can `CreateAccessEntry` only for the agentless role principal, and `AssociateAccessPolicy` only with `AmazonEKSAdminViewPolicy`
- [ ] Org mode: member StackSet instances receive the parameter and create the per-account agentless role

Part of ENG-4257

🤖 Generated with [Claude Code](https://claude.com/claude-code)
