### PR TITLE
Fix DeleteAccessEntry denial in the agentless enrollment policy

### DIFF
--- a/aws-generic/cloud-formation/management-account.yaml
+++ b/aws-generic/cloud-formation/management-account.yaml
@@ -631,16 +631,26 @@ Resources:
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
-          - Sid: EKSManageAgentlessAccessEntry
+          - Sid: EKSCreateAgentlessAccessEntry
             Effect: Allow
             Action:
               - 'eks:CreateAccessEntry'
-              - 'eks:DeleteAccessEntry'
-              - 'eks:DescribeAccessEntry'
-            Resource: '*'
+            Resource: !Sub 'arn:aws:eks:*:${AWS::AccountId}:cluster/*'
             Condition:
               StringEquals:
                 'eks:principalArn': !Sub 'arn:aws:iam::${AWS::AccountId}:role/Dalton-EKS-Agentless-${AWS::AccountId}'
+          # DeleteAccessEntry/DescribeAccessEntry are authorized against the
+          # access-entry resource ARN (which embeds the principal), and the
+          # eks:principalArn condition key is not populated for them — a
+          # StringEquals on it silently denies (hit live: cleanup on datasource
+          # deletion got AccessDeniedException). Scope by resource instead,
+          # exactly like the Associate/Disassociate statement below.
+          - Sid: EKSManageAgentlessAccessEntry
+            Effect: Allow
+            Action:
+              - 'eks:DeleteAccessEntry'
+              - 'eks:DescribeAccessEntry'
+            Resource: !Sub 'arn:aws:eks:*:${AWS::AccountId}:access-entry/*/role/${AWS::AccountId}/Dalton-EKS-Agentless-${AWS::AccountId}/*'
           - Sid: EKSManageAgentlessAccessPolicy
             Effect: Allow
             Action:

--- a/aws-generic/cloud-formation/management-account.yaml
+++ b/aws-generic/cloud-formation/management-account.yaml
@@ -640,10 +640,12 @@ Resources:
               StringEquals:
                 'eks:principalArn': !Sub 'arn:aws:iam::${AWS::AccountId}:role/Dalton-EKS-Agentless-${AWS::AccountId}'
           # DeleteAccessEntry/DescribeAccessEntry are authorized against the
-          # access-entry resource ARN (which embeds the principal), and the
-          # eks:principalArn condition key is not populated for them — a
-          # StringEquals on it silently denies (hit live: cleanup on datasource
-          # deletion got AccessDeniedException). Scope by resource instead,
+          # access-entry resource ARN, and the eks:principalArn condition key
+          # only matches when the entry actually exists. Observed live: the
+          # same conditioned statement allowed deleting an existing entry but
+          # returned AccessDeniedException — not ResourceNotFoundException —
+          # when the entry was absent. Dalton's cleanup and recreate-on-enroll
+          # paths rely on a tolerable not-found, so scope by resource instead,
           # exactly like the Associate/Disassociate statement below.
           - Sid: EKSManageAgentlessAccessEntry
             Effect: Allow

--- a/aws-generic/cloud-formation/single-account.yaml
+++ b/aws-generic/cloud-formation/single-account.yaml
@@ -568,10 +568,12 @@ Resources:
               StringEquals:
                 'eks:principalArn': !Sub 'arn:aws:iam::${AWS::AccountId}:role/Dalton-EKS-Agentless-${AWS::AccountId}'
           # DeleteAccessEntry/DescribeAccessEntry are authorized against the
-          # access-entry resource ARN (which embeds the principal), and the
-          # eks:principalArn condition key is not populated for them — a
-          # StringEquals on it silently denies (hit live: cleanup on datasource
-          # deletion got AccessDeniedException). Scope by resource instead,
+          # access-entry resource ARN, and the eks:principalArn condition key
+          # only matches when the entry actually exists. Observed live: the
+          # same conditioned statement allowed deleting an existing entry but
+          # returned AccessDeniedException — not ResourceNotFoundException —
+          # when the entry was absent. Dalton's cleanup and recreate-on-enroll
+          # paths rely on a tolerable not-found, so scope by resource instead,
           # exactly like the Associate/Disassociate statement below.
           - Sid: EKSManageAgentlessAccessEntry
             Effect: Allow

--- a/aws-generic/cloud-formation/single-account.yaml
+++ b/aws-generic/cloud-formation/single-account.yaml
@@ -559,16 +559,26 @@ Resources:
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
-          - Sid: EKSManageAgentlessAccessEntry
+          - Sid: EKSCreateAgentlessAccessEntry
             Effect: Allow
             Action:
               - 'eks:CreateAccessEntry'
-              - 'eks:DeleteAccessEntry'
-              - 'eks:DescribeAccessEntry'
-            Resource: '*'
+            Resource: !Sub 'arn:aws:eks:*:${AWS::AccountId}:cluster/*'
             Condition:
               StringEquals:
                 'eks:principalArn': !Sub 'arn:aws:iam::${AWS::AccountId}:role/Dalton-EKS-Agentless-${AWS::AccountId}'
+          # DeleteAccessEntry/DescribeAccessEntry are authorized against the
+          # access-entry resource ARN (which embeds the principal), and the
+          # eks:principalArn condition key is not populated for them — a
+          # StringEquals on it silently denies (hit live: cleanup on datasource
+          # deletion got AccessDeniedException). Scope by resource instead,
+          # exactly like the Associate/Disassociate statement below.
+          - Sid: EKSManageAgentlessAccessEntry
+            Effect: Allow
+            Action:
+              - 'eks:DeleteAccessEntry'
+              - 'eks:DescribeAccessEntry'
+            Resource: !Sub 'arn:aws:eks:*:${AWS::AccountId}:access-entry/*/role/${AWS::AccountId}/Dalton-EKS-Agentless-${AWS::AccountId}/*'
           - Sid: EKSManageAgentlessAccessPolicy
             Effect: Allow
             Action:

--- a/aws-generic/cloud-formation/stackset.yaml
+++ b/aws-generic/cloud-formation/stackset.yaml
@@ -564,16 +564,26 @@ Resources:
       PolicyDocument:
         Version: '2012-10-17'
         Statement:
-          - Sid: EKSManageAgentlessAccessEntry
+          - Sid: EKSCreateAgentlessAccessEntry
             Effect: Allow
             Action:
               - 'eks:CreateAccessEntry'
-              - 'eks:DeleteAccessEntry'
-              - 'eks:DescribeAccessEntry'
-            Resource: '*'
+            Resource: !Sub 'arn:aws:eks:*:${AWS::AccountId}:cluster/*'
             Condition:
               StringEquals:
                 'eks:principalArn': !Sub 'arn:aws:iam::${AWS::AccountId}:role/Dalton-EKS-Agentless-${AWS::AccountId}'
+          # DeleteAccessEntry/DescribeAccessEntry are authorized against the
+          # access-entry resource ARN (which embeds the principal), and the
+          # eks:principalArn condition key is not populated for them — a
+          # StringEquals on it silently denies (hit live: cleanup on datasource
+          # deletion got AccessDeniedException). Scope by resource instead,
+          # exactly like the Associate/Disassociate statement below.
+          - Sid: EKSManageAgentlessAccessEntry
+            Effect: Allow
+            Action:
+              - 'eks:DeleteAccessEntry'
+              - 'eks:DescribeAccessEntry'
+            Resource: !Sub 'arn:aws:eks:*:${AWS::AccountId}:access-entry/*/role/${AWS::AccountId}/Dalton-EKS-Agentless-${AWS::AccountId}/*'
           - Sid: EKSManageAgentlessAccessPolicy
             Effect: Allow
             Action:

--- a/aws-generic/cloud-formation/stackset.yaml
+++ b/aws-generic/cloud-formation/stackset.yaml
@@ -573,10 +573,12 @@ Resources:
               StringEquals:
                 'eks:principalArn': !Sub 'arn:aws:iam::${AWS::AccountId}:role/Dalton-EKS-Agentless-${AWS::AccountId}'
           # DeleteAccessEntry/DescribeAccessEntry are authorized against the
-          # access-entry resource ARN (which embeds the principal), and the
-          # eks:principalArn condition key is not populated for them — a
-          # StringEquals on it silently denies (hit live: cleanup on datasource
-          # deletion got AccessDeniedException). Scope by resource instead,
+          # access-entry resource ARN, and the eks:principalArn condition key
+          # only matches when the entry actually exists. Observed live: the
+          # same conditioned statement allowed deleting an existing entry but
+          # returned AccessDeniedException — not ResourceNotFoundException —
+          # when the entry was absent. Dalton's cleanup and recreate-on-enroll
+          # paths rely on a tolerable not-found, so scope by resource instead,
           # exactly like the Associate/Disassociate statement below.
           - Sid: EKSManageAgentlessAccessEntry
             Effect: Allow


### PR DESCRIPTION
## Summary

Splits the agentless enrollment policy's combined Create/Delete/Describe access-entry statement in all three aws-generic CloudFormation templates:

- `eks:CreateAccessEntry` keeps the `eks:principalArn` StringEquals condition (documented and proven to work for Create) and is now scoped to the cluster ARN it actually authorizes against.
- `eks:DeleteAccessEntry` / `eks:DescribeAccessEntry` drop the condition and are instead **resource-scoped** to the agentless role's access-entry ARN pattern (`…:access-entry/*/role/<acct>/Dalton-EKS-Agentless-<acct>/*`) — the same pattern the Associate/Disassociate statement already uses in production.

## Root cause (corrected after CloudTrail analysis)

The `eks:principalArn` condition on `DeleteAccessEntry` **only matches when the access entry actually exists**. CloudTrail from the dev account shows the same policy, same role generation, same request:

- Delete of an **existing** entry → allowed (2026-07-26 10:19Z).
- Delete when **no entry exists** → `AccessDeniedException` instead of `ResourceNotFoundException` (10:56Z, 13:49Z, 14:27Z — and at 14:27:06Z the *same second's* `CreateAccessEntry` succeeded, proving the policy itself was live and healthy).

Dalton's cleanup and recreate-on-enroll paths deliberately rely on a *tolerable not-found* (delete-then-create rebind per ENG-4311; best-effort cleanup per ENG-4310). Under the conditioned statement, every no-entry delete surfaces as a scary AccessDenied "failed" outcome in the deletion report and defeats the ENG-4311 stale-entry rebind. Resource-scoping makes delete authorization independent of entry existence: existing entries delete cleanly, absent entries return ResourceNotFound, which the backend already tolerates.

## Rollout

1. Merge, then sync the three templates to `s3://cf-templates-w9lau7h9v2y20-eu-north-1/aws-generic/`.
2. **Existing stacks do not pick this up automatically** — CloudFormation caches templates. Each installed stack needs an update-stack with the template URL re-specified (including the dev test stack `dalton-aws-integration` in eu-north-1).

## Linear

- [ENG-4257](https://linear.app/dalton-ai/issue/ENG-4257)

Part of ENG-4257

🤖 Generated with [Claude Code](https://claude.com/claude-code)